### PR TITLE
Make mount components, add graceful shutdown

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.4'
+services:
+  bot:
+    image: clojure:openjdk-8-lein-slim-buster
+    working_dir: /app
+    command: lein trampoline run
+    ports:
+      - 7777:3000
+      - 7001:7000
+    volumes:
+      - ./:/app
+      - ~/.m2:/root/.m2
+    environment:
+      - PORT=3000
+      - LIQ_TOKEN="c081648b5122e8"
+      - NREPL_PORT=7000
+      - NREPL_BIND=0.0.0.0
+      - DATABASE_URL=""

--- a/env/dev/clj/user.clj
+++ b/env/dev/clj/user.clj
@@ -1,7 +1,9 @@
 (ns user
   (:require
-    [yamfood.core]
     [yamfood.nrepl]
+    [yamfood.core.db.core]
+    [yamfood.core]
+    [yamfood.tasks.core]
     [mount.core :as mount]
     [environ.core :refer [env]]
     [migratus.core :as migratus]

--- a/src/yamfood/core.clj
+++ b/src/yamfood/core.clj
@@ -1,6 +1,8 @@
 (ns yamfood.core
   (:require
     [aleph.http :as http]
+    [aleph.flow :as flow]
+    [aleph.netty :as netty]
     [compojure.core :as c]
     [mount.core :as mount]
     [yamfood.api.core :as api]
@@ -8,13 +10,16 @@
     [environ.core :refer [env]]
     [compojure.route :as route]
     [yamfood.core.db.init :as db]
-    [yamfood.tasks.core :as tasks]
     [clojure.tools.logging :as log]
     [yamfood.telegram.core :as telegram]
     [yamfood.core.params.core :as params]
     [ring.adapter.jetty :refer [run-jetty]]
-    [ring.middleware.json :refer [wrap-json-body]])
-  (:gen-class))
+    [ring.middleware.json :refer [wrap-json-body]]
+    [yamfood.tasks.core])                                   ;; order is important
+  (:gen-class)
+  (:import (io.aleph.dirigiste Stats$Metric Executor)
+           (java.util.concurrent TimeUnit)
+           (java.util EnumSet)))
 
 
 (c/defroutes
@@ -33,20 +38,43 @@
       (wrap-json-body {:keywords? true})))
 
 
+(mount/defstate ^{:on-reload :noop} executor
+  :start (flow/utilization-executor
+           0.9 512
+           {:metrics (EnumSet/of Stats$Metric/UTILIZATION)})
+  :stop (.shutdown executor))
+
+
 (mount/defstate ^{:on-reload :noop} http-server
   :start
   (let [port (Integer. (or (env :port) 666))]
-    (http/start-server #'app {:port port :join? false}))
+    (http/start-server #'app {:executor           executor
+                              :port               port
+                              :join?              false
+                              :shutdown-executor? false}))
   :stop
-  (.close http-server))
+  (do
+    (log/info "Waiting for all handlers to return (new requests getting HTTP 503)")
+    (.shutdown executor)
+    (.awaitTermination executor 10 TimeUnit/SECONDS)
+    (.close http-server)
+    (netty/wait-for-close http-server)
+    (log/info "HTTP Server closed")))
+
+
+(defn stop-app []
+  (log/info "Shutting down gracefully...")
+  (doseq [component (:stopped (mount/stop))]
+    (log/info component "stopped"))
+  (shutdown-agents))
 
 
 (defn -main []
   (db/init)
   (params/sync-params!)
-  (tasks/run-tasks!)
   (doseq [component (:started (mount/start))]
-    (log/info component "started")))
+    (log/info component "started"))
+  (.addShutdownHook (Runtime/getRuntime) (Thread. stop-app)))
 
 
 ;(def server (-main))

--- a/src/yamfood/core/db/core.clj
+++ b/src/yamfood/core/db/core.clj
@@ -1,14 +1,17 @@
 (ns yamfood.core.db.core
   (:require
+    [mount.core :as mount]
     [jdbc.pool.c3p0 :as pool]
     [environ.core :refer [env]]
     [clj-postgresql.core :as pg]
     [clj-postgresql.types :as pgt]))
 
 
-(def db (pool/make-datasource-spec
-          {:classname      "org.postgresql.Driver"
-           :connection-uri (env :jdbc-database-url)}))
+(mount/defstate db
+  :start (pool/make-datasource-spec
+           {:classname      "org.postgresql.Driver"
+            :connection-uri (env :jdbc-database-url)})
+  :stop (.close db))
 
 
 (defn point->clj

--- a/src/yamfood/core/db/init.clj
+++ b/src/yamfood/core/db/init.clj
@@ -1,11 +1,14 @@
 (ns yamfood.core.db.init
   (:require
     [migratus.core :as migratus]
-    [yamfood.core.db.migrations :as m]))
+    [yamfood.core.db.migrations :as m]
+    [yamfood.core.db.core :refer [db]]
+    [mount.core :as mount]))
 
 
 (defn init []
-  (migratus/migrate m/config))
+  (mount/start #'db)
+  (migratus/migrate (m/config)))
 
 
 ;(init)

--- a/src/yamfood/core/db/migrations.clj
+++ b/src/yamfood/core/db/migrations.clj
@@ -3,8 +3,9 @@
     [yamfood.core.db.core :as db]))
 
 
-(def config {:store                :database
-             :migration-dir        "migrations/"
-             :init-in-transaction? false
-             :migration-table-name "migrations"
-             :db                   db/db})
+(defn config []
+  {:store                :database
+   :migration-dir        "migrations/"
+   :init-in-transaction? false
+   :migration-table-name "migrations"
+   :db                   db/db})

--- a/src/yamfood/nrepl.clj
+++ b/src/yamfood/nrepl.clj
@@ -22,7 +22,7 @@
   :start
   (when (env :nrepl-port)
     (do
-      (log/info "Starting REPL server on port" (env :nrepl-port))
+      (log/info "Starting REPL server on port" (env :nrepl-bind) ":" (Integer. (env :nrepl-port)))
       (nrepl/start-server :port (Integer. (env :nrepl-port)) :bind (env :nrepl-bind))))
   :stop
   (when (env :nrepl-port)

--- a/src/yamfood/tasks/announcements.clj
+++ b/src/yamfood/tasks/announcements.clj
@@ -1,5 +1,6 @@
 (ns yamfood.tasks.announcements
   (:require
+    [clojure.tools.logging :as log]
     [yamfood.core.clients.core :as c]
     [yamfood.core.bots.core :as bots]
     [yamfood.core.announcements.core :as a]
@@ -35,7 +36,7 @@
 (defn announcements-daemon!
   []
   (try
-    (println "Looking for new announcements...")
+    (log/info "Looking for new announcements...")
     (doall
       (->> (a/announcements-to-send!)
            (map send-announcement!)))

--- a/src/yamfood/tasks/core.clj
+++ b/src/yamfood/tasks/core.clj
@@ -1,14 +1,21 @@
 (ns yamfood.tasks.core
   (:require
+    [mount.core :as mount]
     [overtone.at-at :as at]
     [yamfood.tasks.sms :as sms]
     [yamfood.tasks.announcements :as a]))
 
 
-(def pool (at/mk-pool))
-;(at/stop-and-reset-pool! pool)
+(mount/defstate pool
+  :start (at/mk-pool)
+  :stop (at/stop-and-reset-pool! pool))
 
 
-(defn run-tasks! []
-  (at/every 5000 #(a/announcements-daemon!) pool)
-  (at/every 5000 #(sms/sms-daemon!) pool))
+(mount/defstate anouncements
+  :start (at/every 5000 #(a/announcements-daemon!) pool)
+  :stop (at/stop anouncements))
+
+
+(mount/defstate sms
+  :start (at/every 5000 #(sms/sms-daemon!) pool)
+  :stop (at/stop sms))

--- a/src/yamfood/tasks/sms.clj
+++ b/src/yamfood/tasks/sms.clj
@@ -1,5 +1,6 @@
 (ns yamfood.tasks.sms
   (:require
+    [clojure.tools.logging :as log]
     [yamfood.core.params.core :as p]
     [yamfood.core.sms.core :as sms-core]
     [yamfood.integrations.sms.core :as sms-api]))
@@ -21,7 +22,7 @@
 (defn sms-daemon!
   []
   (try
-    (println "Looking for new sms...")
+    (log/info "Looking for new sms...")
     (doall
       (->> (sms-core/sms-to-send! 50)
            (pmap send-sms!)))))


### PR DESCRIPTION
У меня получилось заставить aleph ждать пока все хендлеры проработают, и только потом закрывать соединение. Все кто пытаются подключится к серверу в это время будут получать HTTP 503.
НО: так как я делаю shutdown executor'а, иногда вылетает(например когда открыты сокеты), java.util.concurrent.RejectedExecutionException: Executor is shutdown! at io.aleph.dirigiste.Executor.execute(Executor.java:300) ~[dirigiste-0.1.5.jar:na] at manifold.deferred.Deferred$fn__3445.invoke(deferred.clj:398) [classes/:na] at manifold.deferred.Deferred.success(deferred.clj:398) [classes/:na] at manifold.deferred$success_BANG_.invokeStatic(deferred.clj:243) [classes/:na] at manifold.deferred$success_BANG_.invoke(deferred.clj:240) [classes/:na]

Но оно никак не мешает, все предыдущие запросы отрабатывают и сервер закрывается. Другого способа пока не пока нашёл.